### PR TITLE
Nrn segment section distance scaler

### DIFF
--- a/bluepyopt/ephys/parameterscalers.py
+++ b/bluepyopt/ephys/parameterscalers.py
@@ -296,10 +296,11 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
         # TODO soma needs other addressing scheme
         # find section
         target_sec = None
-        for sec in segment.sec.cell().allsec():
+        for sec in sim.neuron.h.allsec():
             if self.ref_section in sec.name():
                 target_sec = sec
                 break
+
         if target_sec is None:
             raise Exception(f"Could not find section {self.ref_section} in section list")
 

--- a/bluepyopt/ephys/parameterscalers.py
+++ b/bluepyopt/ephys/parameterscalers.py
@@ -255,7 +255,7 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
             for dist_param_name in self.dist_param_names:
                 if dist_param_name not in self.distribution:
                     raise ValueError(
-                        'NrnSegmentSomaDistanceScaler: "{%s}" '
+                        'NrnSegmentSectionDistanceScaler: "{%s}" '
                         'missing from distribution string "%s"'
                         % (dist_param_name, distribution)
                     )

--- a/bluepyopt/ephys/parameterscalers.py
+++ b/bluepyopt/ephys/parameterscalers.py
@@ -219,7 +219,7 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
         distribution=None,
         comment="",
         dist_param_names=None,
-        ref_sec="soma[0]",
+        ref_section="soma[0]",
         ref_location=0,
     ):
         """Constructor
@@ -235,7 +235,7 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
                 object.
                 The distribution string should contain these names, and they
                 will be replaced by values of the corresponding attributes
-            ref_sec (str): string with name of reference section to compute distance (e.g. "soma[0]", "dend[2]")
+            ref_section (str): string with name of reference section to compute distance (e.g. "soma[0]", "dend[2]")
             ref_location (float): location along the soma used as origin
                 from which to compute the distances. Expressed as a fraction
                 (between 0.0 and 1.0).
@@ -246,7 +246,7 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
 
         self.dist_param_names = dist_param_names
         self.ref_location = ref_location
-        self.ref_sec = ref_sec
+        self.ref_section = ref_section
 
         if not (0.0 <= self.ref_location <= 1.0):
             raise ValueError("ref_location must be between 0 and 1.")
@@ -297,11 +297,11 @@ class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
         # find section
         target_sec = None
         for sec in segment.sec.cell().allsec():
-            if self.ref_sec in sec.name():
+            if self.ref_section in sec.name():
                 target_sec = sec
                 break
         if target_sec is None:
-            raise Exception(f"Could not find section {self.ref_sec} in section list")
+            raise Exception(f"Could not find section {self.ref_section} in section list")
 
         # Initialise origin
         sim.neuron.h.distance(0, self.ref_location, sec=target_sec)

--- a/bluepyopt/ephys/parameterscalers.py
+++ b/bluepyopt/ephys/parameterscalers.py
@@ -97,6 +97,8 @@ class NrnSegmentSomaDistanceScaler(ParameterScaler, DictMixin):
         "name",
         "comment",
         "distribution",
+        "dist_param_names",
+        "soma_ref_location",
     )
 
     def __init__(
@@ -115,7 +117,7 @@ class NrnSegmentSomaDistanceScaler(ParameterScaler, DictMixin):
                 from soma. string can contain `distance` and/or `value` as
                 placeholders for the distance to the soma and parameter value
                 respectivily
-            dist_params (list): list of names of parameters that parametrise
+            dist_param_names (list): list of names of parameters that parametrise
                 the distribution. These names will become attributes of this
                 object.
                 The distribution string should contain these names, and they
@@ -182,6 +184,127 @@ class NrnSegmentSomaDistanceScaler(ParameterScaler, DictMixin):
 
         # Initialise origin
         sim.neuron.h.distance(0, self.soma_ref_location, sec=soma)
+
+        distance = sim.neuron.h.distance(1, segment.x, sec=segment.sec)
+
+        # Find something to generalise this
+        import math  # pylint:disable=W0611 #NOQA
+
+        # This eval is unsafe (but is it ever dangerous ?)
+        # pylint: disable=W0123
+        return eval(self.eval_dist(values, distance))
+
+    def __str__(self):
+        """String representation"""
+
+        return self.distribution
+
+
+class NrnSegmentSectionDistanceScaler(ParameterScaler, DictMixin):
+
+    """Scaler based on distance from soma"""
+
+    SERIALIZED_FIELDS = (
+        "name",
+        "comment",
+        "distribution",
+        "dist_param_names",
+        "ref_sec",
+        "ref_location",
+    )
+
+    def __init__(
+        self,
+        name=None,
+        distribution=None,
+        comment="",
+        dist_param_names=None,
+        ref_sec="soma[0]",
+        ref_location=0,
+    ):
+        """Constructor
+
+        Args:
+            name (str): name of this object
+            distribution (str): distribution of parameter dependent on distance
+                from soma. string can contain `distance` and/or `value` as
+                placeholders for the distance to the soma and parameter value
+                respectivily
+            dist_param_names (list): list of names of parameters that parametrise
+                the distribution. These names will become attributes of this
+                object.
+                The distribution string should contain these names, and they
+                will be replaced by values of the corresponding attributes
+            ref_sec (str): string with name of reference section to compute distance (e.g. "soma[0]", "dend[2]")
+            ref_location (float): location along the soma used as origin
+                from which to compute the distances. Expressed as a fraction
+                (between 0.0 and 1.0).
+        """
+
+        super(NrnSegmentSectionDistanceScaler, self).__init__(name, comment)
+        self.distribution = distribution
+
+        self.dist_param_names = dist_param_names
+        self.ref_location = ref_location
+        self.ref_sec = ref_sec
+
+        if not (0.0 <= self.ref_location <= 1.0):
+            raise ValueError("ref_location must be between 0 and 1.")
+
+        if self.dist_param_names is not None:
+            for dist_param_name in self.dist_param_names:
+                if dist_param_name not in self.distribution:
+                    raise ValueError(
+                        'NrnSegmentSomaDistanceScaler: "{%s}" '
+                        'missing from distribution string "%s"'
+                        % (dist_param_name, distribution)
+                    )
+                setattr(self, dist_param_name, None)
+
+    @property
+    def inst_distribution(self):
+        """The instantiated distribution"""
+
+        dist_dict = MissingFormatDict()
+
+        if self.dist_param_names is not None:
+            for dist_param_name in self.dist_param_names:
+                dist_param_value = getattr(self, dist_param_name)
+                if dist_param_value is None:
+                    raise ValueError(
+                        "NrnSegmentSomaDistanceScaler: %s "
+                        "was uninitialised" % dist_param_name
+                    )
+                dist_dict[dist_param_name] = dist_param_value
+
+        # Use this special formatting to bypass missing keys
+        return string.Formatter().vformat(self.distribution, (), dist_dict)
+
+    def eval_dist(self, values, distance):
+        """Create the final dist string"""
+
+        scale_dict = {}
+        for k, v in values.items():
+            scale_dict[k] = format_float(v)
+        scale_dict["distance"] = format_float(distance)
+
+        return self.inst_distribution.format(**scale_dict)
+
+    def scale(self, values, segment, sim=None):
+        """Scale a value based on a segment"""
+
+        # TODO soma needs other addressing scheme
+        # find section
+        target_sec = None
+        for sec in segment.sec.cell().allsec():
+            if self.ref_sec in sec.name():
+                target_sec = sec
+                break
+        if target_sec is None:
+            raise Exception(f"Could not find section {self.ref_sec} in section list")
+
+        # Initialise origin
+        sim.neuron.h.distance(0, self.ref_location, sec=target_sec)
 
         distance = sim.neuron.h.distance(1, segment.x, sec=segment.sec)
 


### PR DESCRIPTION
Added a `NrnSegmentSectionDistanceScaler` in the `parameterscalers.py` to generalize the behavior of the `NrnSegmentSomeDistanceScaler`. 

In brief, it works as the soma scaler, but one can indicate a `ref_section` and a `ref_location`. In our case, we need to define the AIS distributions with respect to section `ais[0](0)`. Then we would instantiate this with `ref_section="ais[0]"` (this is a string used to identify the right section), and `ref_location=0.0`.

