### PR TITLE
Fix extrafel bug in 'single' mode and autocompile of mech folders

### DIFF
--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -497,9 +497,9 @@ class extraFELFeature(EFeature, DictMixin):
 
         feature_value = self.calculate_feature(responses)
 
-        if len(feature_value) == 1:
+        if np.isscalar(feature_value):
             # scalar feature
-            if not np.isfinite(feature_value):
+            if np.isfinite(feature_value):
                 score = np.abs((feature_value - self.exp_mean)) / self.exp_std
             else:
                 score = self.max_score

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -348,7 +348,8 @@ def compile_mech_folder(mech_folder):
     compile_folder = None
 
     if not is_compiled(mech_folder):
-        if any(p.is_file() and p.suffix == ".mod" for p in mech_folder.iterdir()):
+        if any(p.is_file() and p.suffix == ".mod"
+               for p in mech_folder.iterdir()):
             compile_folder = mech_folder
         else:
             for p in mech_folder.iterdir():
@@ -360,5 +361,5 @@ def compile_mech_folder(mech_folder):
             os.chdir(mech_folder)
             os.system(f'nrnivmodl {str(compile_folder)}')
             os.chdir(current_dir)
-        except:
+        except Exception as e:
             os.chdir(current_dir)

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -99,6 +99,7 @@ class NrnSimulator(object):
         if self.mechs_folders is not None:
             import neuron
             for mech_folder in self.mechs_folders:
+                compile_mech_folder(mech_folder)
                 neuron.load_mechanisms(str(mech_folder),
                                        warn_if_already_loaded=False)
 
@@ -245,6 +246,7 @@ class LFPySimulator(object):
         if self.mechs_folders is not None:
             import neuron
             for mech_folder in self.mechs_folders:
+                compile_mech_folder(mech_folder)
                 neuron.load_mechanisms(str(mech_folder),
                                        warn_if_already_loaded=False)
 
@@ -323,3 +325,40 @@ class LFPySimulatorException(Exception):
 
         super(LFPySimulatorException, self).__init__(message)
         self.original = original
+
+
+def is_compiled(mech_folder):
+    from pathlib import Path
+
+    mech_folder = Path(mech_folder)
+    compiled = False
+    for p in mech_folder.iterdir():
+        if p.is_dir() and p.name == "x86_64":
+            compiled = True
+            break
+    return compiled
+
+
+def compile_mech_folder(mech_folder):
+    from pathlib import Path
+    import os
+
+    current_dir = os.getcwd()
+    mech_folder = Path(mech_folder)
+    compile_folder = None
+
+    if not is_compiled(mech_folder):
+        if any(p.is_file() and p.suffix == ".mod" for p in mech_folder.iterdir()):
+            compile_folder = mech_folder
+        else:
+            for p in mech_folder.iterdir():
+                if p.is_dir():
+                    if any(pmod.suffix == '.mod' for pmod in p.iterdir()):
+                        compile_folder = p.name
+        try:
+            print(f"Compiling {str(compile_folder)}")
+            os.chdir(mech_folder)
+            os.system(f'nrnivmodl {str(compile_folder)}')
+            os.chdir(current_dir)
+        except:
+            os.chdir(current_dir)


### PR DESCRIPTION
- Fix extrafel bug in 'single' channel mode (use `np.isscalar` instead of `len`)
- Autocompile mech folders by simulators if `x86_64` is not found